### PR TITLE
fix docker-compose.yml to Readme instruction

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     volumes:
       - ./mysql:/var/lib/mysql
   graphql:
+    container_name: crispy-api
+    image: crispy-api
     build:
       context: .
       target: base


### PR DESCRIPTION
I've made changes in docker-compose file, add image name and container name @kanoru3101 noticed that container name different than in Readme.md